### PR TITLE
Feat : 관리자의 가입 승인 여부 로직 및 API 추가

### DIFF
--- a/backend/controllers/userApprovalController.js
+++ b/backend/controllers/userApprovalController.js
@@ -1,0 +1,95 @@
+// controllers/userApprovalController.js
+
+const TempUser = require("../models/tempuser");
+const RejectedUser = require("../models/rejecteduser");
+const User = require("../models/user");
+const bcrypt = require("bcrypt");
+
+// 모든 가입 요청 조회
+exports.getPendingUsers = async (req, res) => {
+  try {
+    const pendingUsers = await TempUser.find();
+    res.status(200).json(pendingUsers);
+  } catch (error) {
+    res.status(500).json({ message: "가입 요청 목록을 가져올 수 없습니다." });
+  }
+};
+
+// 가입 승인
+exports.approveUser = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const tempUser = await TempUser.findOne({ id });
+
+    if (!tempUser) {
+      return res.status(404).json({ message: "가입 요청을 찾을 수 없습니다." });
+    }
+
+    // 비밀번호 암호화
+    const hashedPassword = await bcrypt.hash(tempUser.password, 10);
+
+    // User 컬렉션으로 이동
+    const newUser = new User({
+      id: tempUser.id,
+      password: hashedPassword,
+      nickName: tempUser.nickName,
+      isAdmin: tempUser.isAdmin,
+      status: tempUser.status,
+      profileImage: tempUser.profileImage,
+      achievements: tempUser.achievements,
+      interests: tempUser.interests,
+    });
+
+    await newUser.save();
+    await TempUser.deleteOne({ id });
+
+    res.status(200).json({ message: "가입이 승인되었습니다.", user: newUser });
+  } catch (error) {
+    res.status(500).json({ message: "가입 승인 실패" });
+  }
+};
+
+// 가입 거절
+exports.rejectUser = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { reason } = req.body;
+    const tempUser = await TempUser.findOne({ id });
+
+    if (!tempUser) {
+      return res.status(404).json({ message: "가입 요청을 찾을 수 없습니다." });
+    }
+
+    // RejectedUser 컬렉션으로 이동
+    const rejectedUser = new RejectedUser({
+      id: tempUser.id,
+      password: tempUser.password, // 해싱 없이 저장 (로그인 X)
+      nickName: tempUser.nickName,
+      isAdmin: tempUser.isAdmin,
+      status: tempUser.status,
+      profileImage: tempUser.profileImage,
+      achievements: tempUser.achievements,
+      interests: tempUser.interests,
+      reason,
+    });
+
+    await rejectedUser.save();
+    await TempUser.deleteOne({ id });
+
+    res.status(200).json({ message: "가입이 거절되었습니다.", rejectedUser });
+  } catch (error) {
+    res.status(500).json({ message: "가입 거절 실패" });
+  }
+};
+
+// 거절된 사용자 목록 조회
+exports.getRejectedUsers = async (req, res) => {
+  try {
+    const rejectedUsers = await RejectedUser.find();
+    res.status(200).json(rejectedUsers);
+  } catch (error) {
+    res
+      .status(500)
+      .json({ message: "거절된 사용자 목록을 가져올 수 없습니다." });
+  }
+};

--- a/backend/routes/userApprovalRoute.js
+++ b/backend/routes/userApprovalRoute.js
@@ -1,0 +1,24 @@
+// routes/userApprovalRoute.js;
+
+const express = require("express");
+const router = express.Router();
+const userApprovalController = require("../controllers/userApprovalController");
+const authMiddleware = require("../middlewares/authMiddleware"); // 관리자 인증용 미들웨어
+
+// 가입 요청 목록 조회 (관리자만) --> 일단
+router.get("/pending", authMiddleware, userApprovalController.getPendingUsers);
+
+// 가입 승인
+router.post("/approve/:id", authMiddleware, userApprovalController.approveUser);
+
+// 가입 거절
+router.post("/reject/:id", authMiddleware, userApprovalController.rejectUser);
+
+// 거절된 사용자 목록 조회
+router.get(
+  "/rejected",
+  authMiddleware,
+  userApprovalController.getRejectedUsers
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ require("dotenv").config(); // 환경변수 로드
 const express = require("express");
 const bodyParser = require("body-parser");
 const authRoutes = require("./routes/authRoute"); // 인증 라우트 불러오기
+const userApprovalRoutes = require("./routes/userApprovalRoutes");
 const db = require("./config/db"); // DB 연결 모듈 불러오기
 const app = express();
 const path = require("path"); // path 모듈 추가
@@ -28,6 +29,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 // 라우팅 설정
 app.use("/", authRoutes); // 인증 관련 라우트
+app.use("/user-approval", userApprovalRoutes); // 관리자 승인 라우트트
 
 // 에러 핸들링 미들웨어
 app.use((err, req, res, next) => {


### PR DESCRIPTION
관리자는 전체 가입 요청을 확인할 수 있고, 사용자의 가입을 승인/거절할 수 있습니다.
관리자 전용 미들웨어를 추가할까 싶은데 일단은 간단 로직만 추가해보았습니다
인자를 params로 받는 부분은 UX 상 좋지 않을 것 같아 추후 수정할까 합니다.